### PR TITLE
Update background-script.js

### DIFF
--- a/background-script.js
+++ b/background-script.js
@@ -1,7 +1,7 @@
 ﻿// this background script is used to invoke desktopCapture API
 // to capture screen-MediaStream.
 
-var screenOptions = ['screen', 'window'];
+var screenOptions = ['screen', 'window', 'tab'];
 
 chrome.runtime.onConnect.addListener(function (port) {
     port.onMessage.addListener(portOnMessageHanlder);


### PR DESCRIPTION
Hello,

I've added `tab` sharing capability 

Please note ;
I've read the facebook extension code and this is in comment

>  Capturing a tab using chooseDesktopMedia is not supported in older versions
>   on Mac. A bug number identifying when this was fixed can not be found. The
>   solution is to check for a specific exception message and try to invoke the
>   media picker with only "screen" and "window".